### PR TITLE
Improve PHPUnit fixture methods

### DIFF
--- a/src/Rules/Captcha.php
+++ b/src/Rules/Captcha.php
@@ -47,8 +47,8 @@ class Captcha implements Rule
      */
     public function message()
     {
-        if($this->serviceResponse['error-codes'] === null) {
-            return "simple-recaptcha-v3::messages.response-null";
+        if ($this->serviceResponse['error-codes'] === null) {
+            return 'simple-recaptcha-v3::messages.response-null';
         }
 
         return "simple-recaptcha-v3::messages.{$this->serviceResponse['error-codes'][0]}";

--- a/tests/RuleTest.php
+++ b/tests/RuleTest.php
@@ -6,7 +6,7 @@ use Torralbodavid\SimpleRecaptchaV3\Rules\Captcha as CaptchaRule;
 
 class RuleTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SnippetsTest.php
+++ b/tests/SnippetsTest.php
@@ -4,7 +4,7 @@ namespace Torralbodavid\SimpleRecaptchaV3\Tests;
 
 class SnippetsTest extends TestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -8,7 +8,7 @@ use Torralbodavid\SimpleRecaptchaV3\SimpleRecaptchaV3ServiceProvider;
 
 class TestCase extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
# Pull Request Template

## Purpose

- Improvements for PHPUnit fixture methods.
- According to the [PHPUnit fixtures reference](https://phpunit.readthedocs.io/en/9.3/fixtures.html#more-setup-than-teardown), it should be `protected function setUp(): void`.

## Approach

N/A

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Improvements

## QA Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
