### PR TITLE
Remove async attribute to avoid errors.

### DIFF
--- a/resources/views/captcha-init.blade.php
+++ b/resources/views/captcha-init.blade.php
@@ -2,7 +2,7 @@
     @if(config('simple-recaptcha-v3.hide_badge'))
         <style> .grecaptcha-badge { visibility: hidden; } </style>
     @endif
-    <script async defer src="https://www.google.com/recaptcha/api.js?render={{ config('simple-recaptcha-v3.site_key') }}{{ (! config('simple-recaptcha-v3.prefer_navigator_language')) ? '&hl='.app()->getLocale() : '' }}"></script>
+    <script defer src="https://www.google.com/recaptcha/api.js?render={{ config('simple-recaptcha-v3.site_key') }}{{ (! config('simple-recaptcha-v3.prefer_navigator_language')) ? '&hl='.app()->getLocale() : '' }}"></script>
     <script type="application/javascript">
         function prepareCaptcha(action, id) {
             grecaptcha.ready(() => {


### PR DESCRIPTION
# Pull Request

## Purpose

Recaptcha script had "async" attribute, which told the browser that DOM doesn't have to wait for the script, what led to error as DOM didn't find grecaptcha object.

## Approach

Removing "async" attribute is enough and keeping "defer" attribute as it improves performing but executes the script before DOMContentLoaded.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## QA Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings
